### PR TITLE
fix: 웹소켓 연결 프록시패스 이슈 임시 해결

### DIFF
--- a/src/nginx/nginx.conf
+++ b/src/nginx/nginx.conf
@@ -41,10 +41,10 @@ http {
         }
 
         # NOTE: admin, static이후 production에서는 뺄 수도...
-        location ~ ^/(admin|static|login|oauth|valid|api|ws|socket.io) {
-            if ($http_referer !~* ^https://localhost) {
-                return 403;
-            }
+        location ~ ^/(admin|static|login|oauth|valid|api|socket.io) {
+            # if ($http_referer !~* ^https://localhost) {
+            #     return 403;
+            # }
             proxy_pass http://backend$request_uri;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
`ws://`로 시작하는 웹소켓 통신 경로에 대해 제대로 연결되지 않는 문제가 있어 임시로 해결하였습니다.

- nginx config의 `http_referer` 조건문이 원인이었음
- 당장 테스트에 문제가 있어 임시방편으로 수정
- 추후 해당 문제를 피하면서 목적을 이루기 위한 방법 강구해야함